### PR TITLE
i915: dip_infoframe should be aligned to 4 bytes

### DIFF
--- a/usr/src/uts/intel/io/i915/intel_drv.h
+++ b/usr/src/uts/intel/io/i915/intel_drv.h
@@ -435,7 +435,7 @@ struct dip_infoframe {
 		} spd;
 		uint8_t payload[27];
 	} __attribute__ ((packed)) body;
-} __attribute__((packed));
+} __attribute__((packed, aligned(4)));
 
 struct intel_hdmi {
 	u32 hdmi_reg;


### PR DESCRIPTION
The `struct dip_infoframe` is packed and so the compiler does not guarantee its alignment (IOW, a variable of such a type could be placed possibly at any address).  However, there are few places in the `intel_hdmi.c` file where we cast a pointer to `struct dip_infoframe` to `uint32_t *`.  This could possibly cause unaligned pointer access in those functions.  Fortunately, this is not a problem with the current code because all variables of type `struct dip_infoframe` are already properly aligned to 4 bytes and so the unaligned access cannot happen.

However, when I try to compile `gfx-drm` using gcc 10 (the currently used gcc is version 7) then I see errors like:
```
../../intel/io/i915/intel_hdmi.c: In function 'g4x_write_infoframe':
../../intel/io/i915/intel_hdmi.c:144:2: error: converting a packed 'struct dip_infoframe' pointer (alignment 1) to a 'uint32_t' {aka 'unsigned int'} pointer (alignment 4) may result in an unaligned pointer value [-Werror=address-of-packed-member]
  144 |  uint32_t *data = (uint32_t *)frame;
      |  ^~~~~~~~
In file included from ../../intel/io/i915/intel_hdmi.c:37:
../../intel/io/i915/intel_drv.h:407:8: note: defined here
  407 | struct dip_infoframe {
      |        ^~~~~~~~~~~~~
../../intel/io/i915/intel_hdmi.c: In function 'ibx_write_infoframe':
../../intel/io/i915/intel_hdmi.c:182:2: error: converting a packed 'struct dip_infoframe' pointer (alignment 1) to a 'uint32_t' {aka 'unsigned int'} pointer (alignment 4) may result in an unaligned pointer value [-Werror=address-of-packed-member]
  182 |  uint32_t *data = (uint32_t *)frame;
      |  ^~~~~~~~
In file included from ../../intel/io/i915/intel_hdmi.c:37:
../../intel/io/i915/intel_drv.h:407:8: note: defined here
  407 | struct dip_infoframe {
      |        ^~~~~~~~~~~~~
```
Apparently, newer gcc versions are picky and (properly) detects the possible unaligned pointer access.

This PR is to make sure that all `struct dip_infoframe` variables are always explicitly aligned to (at least) 4 bytes and so the newer compilers would be happy.