### PR TITLE
devfsadm: use LINK.c to link SUNW_drm_link_i386.so

### DIFF
--- a/usr/src/cmd/devfsadm/Makefile.com
+++ b/usr/src/cmd/devfsadm/Makefile.com
@@ -87,7 +87,7 @@ lint:
 include ../../Makefile.targ
 
 SUNW_%.so: %.o $(MAPFILES)
-	$(CC) -o $@ $(GSHARED) $(DYNFLAGS) -h $@ $< $(LDLIBS) -lc
+	$(LINK.c) -o $@ $(GSHARED) $(DYNFLAGS) -h $@ $< $(LDLIBS) -lc
 	$(POST_PROCESS_SO)
 
 %.o: $(COMMON)/%.c


### PR DESCRIPTION
Currently, the `$(CC)` is used to link `SUNW_drm_link_i386.so`.  This works mostly okay, except the actual linking command lacks the explicit `-m32`.  This is not a problem when we build using `gcc-7` where `-m32` is the default.

To make sure the `SUNW_drm_link_i386.so` build works properly with our newer compilers where the default is `-m64` we need to make sure there is the proper command used for linking.  Such command is stored in `$(LINK.c)` and its usage will bring the needed `-mXX` for us.