### PR TITLE
drm-tests: Run_all.sh should not run 32-bit tests since they are gone

### DIFF
--- a/usr/src/cmd/drm-tests/Run_all.sh
+++ b/usr/src/cmd/drm-tests/Run_all.sh
@@ -47,8 +47,5 @@ for f in $TESTS ; do
 done
 }
 
-echo "Running all (32-bit)" >&2
-run_all /opt/drm-tests
-
 echo "Running all (64-bit)" >&2
 run_all /opt/drm-tests/amd64


### PR DESCRIPTION
They were removed [nine months ago](https://github.com/OpenIndiana/gfx-drm/commit/de94e317caffe7347b1d0fed520bbf03c05fdb85).