### PR TITLE
libdrm: report modesetting support

### DIFF
--- a/usr/src/common/libdrm/patches/modesetting.patch
+++ b/usr/src/common/libdrm/patches/modesetting.patch
@@ -1,0 +1,11 @@
+--- libdrm-2.4.109/xf86drmMode.c.orig
++++ libdrm-2.4.109/xf86drmMode.c
+@@ -960,6 +960,8 @@
+ 
+ 	drmClose(fd);
+ 	return 0;
++#elif defined(__illumos__)
++	return 0;
+ #endif
+ 	return -ENOSYS;
+ }


### PR DESCRIPTION
This basically adds back the patch that got removed as part of https://github.com/OpenIndiana/gfx-drm/commit/6ec9a1e9e1a418dd8f72cd4f1645849ec2ad10da.  This fixes https://www.illumos.org/issues/16629.